### PR TITLE
feat: MBTI 밸런스 게임 (Korean viral poll)

### DIFF
--- a/app/api/balance/questions/route.ts
+++ b/app/api/balance/questions/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+import { BALANCE_QUESTIONS } from "@/lib/balance-questions";
+
+export async function GET() {
+  return NextResponse.json({ questions: BALANCE_QUESTIONS });
+}

--- a/app/api/balance/vote/route.ts
+++ b/app/api/balance/vote/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getQuestionById } from "@/lib/balance-questions";
+import { saveVoteAndLoad } from "@/lib/balance-store";
+import { isValidMbtiType, normalizeType } from "@/lib/mbti";
+
+type VoteBody = {
+  questionId?: string;
+  choice?: "A" | "B";
+  mbtiType?: string;
+};
+
+type VoteRow = {
+  question_id: string;
+  choice: "A" | "B";
+  mbti_type: string;
+};
+
+function buildCommentary(questionPrompt: string, aCount: number, bCount: number, aTop: string[], bTop: string[]) {
+  const winner = aCount === bCount ? "팽팽" : aCount > bCount ? "A" : "B";
+  const lead = Math.abs(aCount - bCount);
+  const topA = aTop.length ? aTop.join(", ") : "아직 데이터 적음";
+  const topB = bTop.length ? bTop.join(", ") : "아직 데이터 적음";
+
+  return `🧠 Council 코멘트 — "${questionPrompt}"는 ${winner === "팽팽" ? "완전 반반" : `${winner} 쪽 우세(${lead}표 차)`} 분위기. A는 ${topA} 타입이 많이 고르고, B는 ${topB} 타입이 많이 고르는 중!`;
+}
+
+function summarize(rows: VoteRow[]) {
+  const total = rows.length;
+  const aRows = rows.filter((r) => r.choice === "A");
+  const bRows = rows.filter((r) => r.choice === "B");
+
+  const byType: Record<string, { A: number; B: number; total: number; lean: "A" | "B" | "tie" }> = {};
+  for (const row of rows) {
+    const type = row.mbti_type.toUpperCase();
+    if (!byType[type]) byType[type] = { A: 0, B: 0, total: 0, lean: "tie" };
+    byType[type]!.total += 1;
+    byType[type]![row.choice] += 1;
+  }
+
+  for (const type of Object.keys(byType)) {
+    const item = byType[type]!;
+    item.lean = item.A === item.B ? "tie" : item.A > item.B ? "A" : "B";
+  }
+
+  const topA = Object.entries(byType)
+    .filter(([, v]) => v.lean === "A")
+    .sort((a, b) => b[1].A - a[1].A)
+    .slice(0, 3)
+    .map(([t]) => t);
+
+  const topB = Object.entries(byType)
+    .filter(([, v]) => v.lean === "B")
+    .sort((a, b) => b[1].B - a[1].B)
+    .slice(0, 3)
+    .map(([t]) => t);
+
+  return {
+    total,
+    A: { count: aRows.length, percent: total ? Math.round((aRows.length / total) * 100) : 0, topTypes: topA },
+    B: { count: bRows.length, percent: total ? Math.round((bRows.length / total) * 100) : 0, topTypes: topB },
+    byType,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as VoteBody;
+    const questionId = (body.questionId || "").trim();
+    const choice = body.choice;
+    const mbtiType = normalizeType(body.mbtiType || "");
+
+    const question = getQuestionById(questionId);
+    if (!question) return NextResponse.json({ error: "Invalid questionId" }, { status: 400 });
+    if (choice !== "A" && choice !== "B") return NextResponse.json({ error: "Invalid choice" }, { status: 400 });
+    if (!isValidMbtiType(mbtiType)) return NextResponse.json({ error: "Invalid MBTI type" }, { status: 400 });
+
+    const { rows, source } = await saveVoteAndLoad(questionId, choice, mbtiType);
+
+    const stats = summarize(rows as VoteRow[]);
+    const commentary = buildCommentary(question.prompt, stats.A.count, stats.B.count, stats.A.topTypes, stats.B.topTypes);
+
+    return NextResponse.json({ questionId, stats, commentary, source });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/balance/page.tsx
+++ b/app/balance/page.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+
+import { MBTI_TYPES } from "@/app/lib/mbti";
+
+type Choice = "A" | "B";
+
+type Question = {
+  id: string;
+  prompt: string;
+  choices: Array<{ id: Choice; text: string; leanType: string }>;
+};
+
+type VoteStats = {
+  total: number;
+  A: { count: number; percent: number; topTypes: string[] };
+  B: { count: number; percent: number; topTypes: string[] };
+  byType: Record<string, { A: number; B: number; total: number; lean: "A" | "B" | "tie" }>;
+};
+
+function parseBreakdown(raw: string | null) {
+  if (!raw) return [] as Array<[string, number]>;
+  return raw
+    .split(",")
+    .map((item) => item.split(":"))
+    .filter((v) => v.length === 2)
+    .map(([k, v]) => [k, Number(v)] as [string, number])
+    .filter(([, n]) => Number.isFinite(n));
+}
+
+export default function BalancePage() {
+  const [sharedType, setSharedType] = useState<string | null>(null);
+  const [sharedScore, setSharedScore] = useState<string | null>(null);
+  const [sharedBreakdown, setSharedBreakdown] = useState<Array<[string, number]>>([]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const sp = new URLSearchParams(window.location.search);
+    setSharedType(sp.get("type"));
+    setSharedScore(sp.get("score"));
+    setSharedBreakdown(parseBreakdown(sp.get("breakdown")));
+  }, []);
+
+  const isSharedResult = Boolean(sharedType && sharedScore);
+
+  const [mbtiType, setMbtiType] = useState("ENFP");
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [index, setIndex] = useState(0);
+  const [stats, setStats] = useState<VoteStats | null>(null);
+  const [commentary, setCommentary] = useState("");
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [done, setDone] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const current = questions[index];
+
+  const result = useMemo(() => {
+    const values = Object.values(answers);
+    if (!values.length) return null;
+
+    const counts: Record<string, number> = {};
+    for (const type of values) counts[type] = (counts[type] || 0) + 1;
+
+    const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+    const top = sorted[0];
+    if (!top) return null;
+
+    const score = Math.round((top[1] / values.length) * 100);
+    return {
+      type: top[0],
+      score,
+      breakdown: sorted,
+    };
+  }, [answers]);
+
+  async function start() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/balance/questions");
+      const data = await res.json();
+      setQuestions(data.questions || []);
+      setIndex(0);
+      setStats(null);
+      setAnswers({});
+      setDone(false);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function vote(choice: Choice) {
+    if (!current) return;
+    const pickedLeanType = current.choices.find((c) => c.id === choice)?.leanType;
+
+    const res = await fetch("/api/balance/vote", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        questionId: current.id,
+        choice,
+        mbtiType,
+      }),
+    });
+
+    const data = await res.json();
+    if (!res.ok) {
+      alert(data?.error || "투표 저장 실패");
+      return;
+    }
+
+    setStats(data.stats as VoteStats);
+    setCommentary(String(data.commentary || ""));
+    if (pickedLeanType) {
+      setAnswers((prev) => ({ ...prev, [current.id]: pickedLeanType }));
+    }
+  }
+
+  function next() {
+    setStats(null);
+    setCommentary("");
+    if (index + 1 >= questions.length) {
+      setDone(true);
+      return;
+    }
+    setIndex((v) => v + 1);
+  }
+
+  async function copyShare() {
+    if (!result) return;
+    const url = `${window.location.origin}/balance?type=${encodeURIComponent(result.type)}&score=${result.score}&breakdown=${encodeURIComponent(result.breakdown.map(([t, n]) => `${t}:${n}`).join(","))}`;
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  if (isSharedResult) {
+    return (
+      <main className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-rose-50 px-4 py-10 text-gray-900">
+        <div className="mx-auto max-w-xl rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
+          <p className="text-xs font-bold text-fuchsia-700">MBTI 밸런스 게임 결과</p>
+          <h1 className="mt-2 text-3xl font-black">나는 {sharedScore}% {sharedType} 성향</h1>
+          <div className="mt-4 space-y-2">
+            {sharedBreakdown.map(([type, count]) => (
+              <div key={type} className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-sm">
+                <span>{type}</span>
+                <span>{count}표</span>
+              </div>
+            ))}
+          </div>
+          <Link href="/balance" className="mt-5 inline-flex rounded-xl bg-gray-900 px-4 py-2 text-sm font-bold text-white">
+            나도 해보기 →
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-rose-50 px-4 py-8 text-gray-900">
+      <div className="mx-auto max-w-2xl">
+        <h1 className="text-3xl font-black">MBTI 밸런스 게임</h1>
+        <p className="mt-2 text-sm text-gray-600">30초 컷. 선택하고, 실시간 MBTI 성향 분포를 확인해봐 🔥</p>
+
+        {!questions.length ? (
+          <div className="mt-6 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+            <label className="text-sm font-bold">내 MBTI</label>
+            <select value={mbtiType} onChange={(e) => setMbtiType(e.target.value)} className="mt-2 h-11 w-full rounded-xl border border-gray-300 px-3 text-sm">
+              {MBTI_TYPES.map((t) => (
+                <option key={t.code} value={t.code}>{t.emoji} {t.code}</option>
+              ))}
+            </select>
+            <button onClick={() => void start()} disabled={loading} className="mt-4 w-full rounded-2xl bg-gray-900 py-3 text-sm font-extrabold text-white">
+              {loading ? "불러오는 중..." : "게임 시작"}
+            </button>
+          </div>
+        ) : done && result ? (
+          <div className="mt-6 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-bold text-fuchsia-700">결과 요약</p>
+            <h2 className="mt-2 text-2xl font-black">나는 {result.score}% {result.type} 성향</h2>
+            <div className="mt-4 space-y-2">
+              {result.breakdown.map(([type, count]) => (
+                <div key={type} className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-sm">
+                  <span>{type}</span>
+                  <span>{count}개 선택</span>
+                </div>
+              ))}
+            </div>
+            <div className="mt-4 flex gap-2">
+              <button onClick={() => void copyShare()} className="rounded-xl border border-gray-300 px-4 py-2 text-sm font-bold">{copied ? "복사됨!" : "결과 링크 복사"}</button>
+              <button onClick={() => { setQuestions([]); setDone(false); }} className="rounded-xl bg-gray-900 px-4 py-2 text-sm font-bold text-white">다시하기</button>
+            </div>
+          </div>
+        ) : current ? (
+          <div className="mt-6 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-bold text-gray-500">문항 {index + 1} / {questions.length}</p>
+            <h2 className="mt-2 text-xl font-black">{current.prompt}</h2>
+
+            <div className="mt-4 grid gap-2">
+              {current.choices.map((choice) => (
+                <button key={choice.id} onClick={() => void vote(choice.id)} disabled={Boolean(stats)} className="rounded-xl border border-gray-300 bg-white px-4 py-3 text-left text-sm font-semibold hover:border-gray-400 disabled:opacity-60">
+                  {choice.text}
+                </button>
+              ))}
+            </div>
+
+            {stats ? (
+              <div className="mt-5 space-y-3 rounded-xl border border-gray-200 bg-gray-50 p-3">
+                <div className="grid grid-cols-2 gap-2 text-sm">
+                  <div className="rounded-lg border border-gray-200 bg-white p-2">
+                    <p className="font-bold">A {stats.A.percent}%</p>
+                    <p className="text-xs text-gray-500">{stats.A.count}표 · {stats.A.topTypes.join(", ") || "-"}</p>
+                  </div>
+                  <div className="rounded-lg border border-gray-200 bg-white p-2">
+                    <p className="font-bold">B {stats.B.percent}%</p>
+                    <p className="text-xs text-gray-500">{stats.B.count}표 · {stats.B.topTypes.join(", ") || "-"}</p>
+                  </div>
+                </div>
+
+                <div className="rounded-lg border border-fuchsia-200 bg-fuchsia-50 p-3 text-xs text-gray-700">
+                  {commentary}
+                </div>
+
+                <div className="max-h-40 overflow-auto rounded-lg border border-gray-200 bg-white p-2 text-xs">
+                  <p className="mb-1 font-semibold">MBTI별 성향</p>
+                  <div className="space-y-1">
+                    {Object.entries(stats.byType).sort((a, b) => b[1].total - a[1].total).map(([type, v]) => (
+                      <div key={type} className="flex items-center justify-between">
+                        <span>{type}</span>
+                        <span>{v.lean === "tie" ? "반반" : `${v.lean} 성향`} ({v.total})</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <button onClick={next} className="w-full rounded-xl bg-gray-900 py-2 text-sm font-bold text-white">다음 문항</button>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,6 +57,12 @@ export default async function HomePage() {
           >
             오늘의 운세 보기 →
           </Link>
+          <Link
+            href="/balance"
+            className="inline-flex min-h-14 items-center justify-center rounded-2xl border border-indigo-200 bg-indigo-50 px-6 text-base font-bold text-indigo-800 shadow-sm transition hover:-translate-y-0.5 hover:border-indigo-300"
+          >
+            MBTI 밸런스 게임 →
+          </Link>
         </div>
       </section>
 

--- a/lib/balance-questions.ts
+++ b/lib/balance-questions.ts
@@ -1,0 +1,58 @@
+export type BalanceChoice = {
+  id: "A" | "B";
+  text: string;
+  leanType: string;
+};
+
+export type BalanceQuestion = {
+  id: string;
+  prompt: string;
+  choices: [BalanceChoice, BalanceChoice];
+};
+
+export const BALANCE_QUESTIONS: BalanceQuestion[] = [
+  { id: "q1", prompt: "연애할 때 더 끌리는 건?", choices: [
+    { id: "A", text: "ENFP처럼 매일 새 취미 같이 도전", leanType: "ENFP" },
+    { id: "B", text: "ISTJ처럼 같은 루틴 10년 유지", leanType: "ISTJ" },
+  ]},
+  { id: "q2", prompt: "회사에서 더 편한 스타일은?", choices: [
+    { id: "A", text: "ENTJ처럼 결론부터 3줄 보고", leanType: "ENTJ" },
+    { id: "B", text: "INFP처럼 맥락+감정까지 풀설명", leanType: "INFP" },
+  ]},
+  { id: "q3", prompt: "주말 계획, 당신의 선택은?", choices: [
+    { id: "A", text: "ISFP처럼 즉흥 드라이브", leanType: "ISFP" },
+    { id: "B", text: "INTJ처럼 시간표 꽉 채운 하루", leanType: "INTJ" },
+  ]},
+  { id: "q4", prompt: "썸 연락 템포는?", choices: [
+    { id: "A", text: "ESTP처럼 5분 안에 바로 답장", leanType: "ESTP" },
+    { id: "B", text: "INFJ처럼 생각 정리 후 답장", leanType: "INFJ" },
+  ]},
+  { id: "q5", prompt: "팀플에서 맡고 싶은 역할은?", choices: [
+    { id: "A", text: "ENFJ처럼 분위기+조율 담당", leanType: "ENFJ" },
+    { id: "B", text: "INTP처럼 구조 설계+핵심 논리", leanType: "INTP" },
+  ]},
+  { id: "q6", prompt: "여행 가면 더 행복한 순간은?", choices: [
+    { id: "A", text: "ESFP처럼 현지에서 우연히 놀 거리 발견", leanType: "ESFP" },
+    { id: "B", text: "ISTJ처럼 계획한 코스 완주", leanType: "ISTJ" },
+  ]},
+  { id: "q7", prompt: "갈등 생기면 어떻게 풀래?", choices: [
+    { id: "A", text: "ENTP처럼 토론으로 끝장보기", leanType: "ENTP" },
+    { id: "B", text: "ISFJ처럼 조용히 배려하며 봉합", leanType: "ISFJ" },
+  ]},
+  { id: "q8", prompt: "돈 생기면 먼저 하는 건?", choices: [
+    { id: "A", text: "ESTJ처럼 예산표부터 업데이트", leanType: "ESTJ" },
+    { id: "B", text: "ENFP처럼 일단 경험에 투자", leanType: "ENFP" },
+  ]},
+  { id: "q9", prompt: "카톡방에서 내 역할은?", choices: [
+    { id: "A", text: "ESFJ처럼 반응 이모지+분위기 메이커", leanType: "ESFJ" },
+    { id: "B", text: "INTJ처럼 핵심 한 줄 요약러", leanType: "INTJ" },
+  ]},
+  { id: "q10", prompt: "인생 만족감이 큰 순간은?", choices: [
+    { id: "A", text: "INFP처럼 의미 있는 대화 후 여운", leanType: "INFP" },
+    { id: "B", text: "ENTJ처럼 목표 달성 체크 완료", leanType: "ENTJ" },
+  ]},
+];
+
+export function getQuestionById(questionId: string) {
+  return BALANCE_QUESTIONS.find((q) => q.id === questionId) || null;
+}

--- a/lib/balance-store.ts
+++ b/lib/balance-store.ts
@@ -1,0 +1,62 @@
+import { kv } from "@vercel/kv";
+
+import { db } from "@/lib/db";
+
+type VoteRow = {
+  question_id: string;
+  choice: "A" | "B";
+  mbti_type: string;
+};
+
+const memoryVotes = new Map<string, VoteRow[]>();
+
+function isSupabaseTableMissing(error: unknown) {
+  const msg = error instanceof Error ? error.message : String(error || "");
+  return msg.includes("Could not find the table") || msg.includes("schema cache");
+}
+
+export async function saveVoteAndLoad(questionId: string, choice: "A" | "B", mbtiType: string): Promise<{ rows: VoteRow[]; source: string }> {
+  // 1) Supabase (primary)
+  try {
+    const { error: insertError } = await db.from("balance_votes").insert({
+      question_id: questionId,
+      choice,
+      mbti_type: mbtiType,
+    });
+    if (insertError) throw new Error(insertError.message);
+
+    const { data, error } = await db
+      .from("balance_votes")
+      .select("question_id, choice, mbti_type")
+      .eq("question_id", questionId);
+    if (error) throw new Error(error.message);
+
+    return { rows: (data || []) as VoteRow[], source: "supabase" };
+  } catch (error) {
+    if (!isSupabaseTableMissing(error)) {
+      throw error;
+    }
+  }
+
+  // 2) Vercel KV fallback (persistent)
+  try {
+    const key = `balance:votes:${questionId}`;
+    const entry: VoteRow = { question_id: questionId, choice, mbti_type: mbtiType };
+    await kv.rpush(key, JSON.stringify(entry));
+    const raw = (await kv.lrange<string[]>(key, 0, -1)) || [];
+    const rows = raw.map((v) => {
+      try {
+        return JSON.parse(String(v)) as VoteRow;
+      } catch {
+        return null;
+      }
+    }).filter(Boolean) as VoteRow[];
+    return { rows, source: "vercel-kv" };
+  } catch {
+    // 3) in-memory fallback (dev safety)
+    const arr = memoryVotes.get(questionId) || [];
+    arr.push({ question_id: questionId, choice, mbti_type: mbtiType });
+    memoryVotes.set(questionId, arr);
+    return { rows: arr, source: "memory" };
+  }
+}


### PR DESCRIPTION
## Summary
- add `/balance` Korean-first MBTI balance game UI
- 10 curated Korean balance questions
- users vote and immediately see split stats + MBTI type lean breakdown
- shareable result link (`나는 XX% TYPE 성향`)
- homepage entry button: `MBTI 밸런스 게임 →`

## API
- `GET /api/balance/questions`
- `POST /api/balance/vote`

## Data storage
- primary: Supabase table `balance_votes` (if available)
- fallback: Vercel KV
- dev fallback: in-memory store

## Notes
- includes lightweight "Council commentary" on each question split
- built for fast 30-second engagement loop

## Local validation
- `npm run build` passes
- `/balance` loads and flow works
- vote endpoint returns live aggregated stats
